### PR TITLE
feature: Add field filtering to Loki logs

### DIFF
--- a/packages/utils/src/loki.js
+++ b/packages/utils/src/loki.js
@@ -36,7 +36,7 @@ import { nanoid } from 'nanoid/non-secure'
  * @property {string} level
  * @property {Metadata} metadata
  *
- * @typedef {(log: Log) => object} FilterFieldsCallback
+ * @typedef {(log: Log) => object} LogDataTransformerCallback
  */
 
 export class Logging {
@@ -53,13 +53,13 @@ export class Logging {
    * @param {string} opts.worker
    * @param {string} opts.env
    * @param {import('toucan-js').Toucan} [opts.sentry]
-   * @param {FilterFieldsCallback} [opts.filterFields] - Callback to filter log fields
+   * @param {LogDataTransformerCallback} [opts.logDataTransformer] - Callback to filter or transform log fields
    */
   constructor(request, context, opts) {
     this.request = request
     this.context = context
     this.opts = opts
-    this.filterFields = opts.filterFields
+    this.logDataTransformer = opts.logDataTransformer
 
     this._times = new Map()
     /**
@@ -241,12 +241,12 @@ export class Logging {
   }
 
   /**
-   * Add log entry to batch after applying field filtering
+   * Add log entry to batch after applying logDataTransformer
    *
    * @param {any} body
    */
   _add(body) {
-    const log = this.filterFields ? this.filterFields(body) : body
+    const log = this.logDataTransformer ? this.logDataTransformer(body) : body
     this.logEventsBatch.push(log)
   }
 

--- a/packages/utils/test/loki.test.js
+++ b/packages/utils/test/loki.test.js
@@ -17,6 +17,33 @@ function logging() {
   )
 }
 
+function loggingWithFilteredFields() {
+  return new Logging(
+    new Request('http://localhost'),
+    { waitUntil: async () => {}, passThroughOnException: () => {} },
+    {
+      url: 'test',
+      worker: 'test',
+      branch: 'test',
+      commit: 'test',
+      version: 'test',
+      env: 'test',
+      filterFields: (log) => {
+        const { metadata } = log
+        // Customize which fields to include
+        const filteredMetadata = {
+          request: {
+            url: metadata.request.url,
+            method: metadata.request.method,
+          },
+          response: metadata.response,
+        }
+        return { ...log, metadata: filteredMetadata }
+      },
+    }
+  )
+}
+
 test('should add a log to the batch ', async (t) => {
   const log = logging()
 
@@ -50,6 +77,68 @@ test('should not log with timeend', async (t) => {
     log._times.get('testing').duration,
     log._times.get('testing').end - log._times.get('testing').start
   )
+})
+
+test('should log with filtered log fields', async (t) => {
+  const log = loggingWithFilteredFields()
+
+  /**
+   * @type {import('../src/loki.js').Metadata}
+   */
+  const metadata = {
+    request: {
+      url: 'https://bafybeigbj3eeda2x7i5jdkvm5pljdxnwo5n3eripduhcsmwpm111111111.ipfs.nftstorage.link/mockFile.json',
+      method: 'GET',
+      headers: {
+        accept: '*/*',
+        accept_encoding: 'gzip',
+        accept_language: '*',
+        cache_control: 'only-if-cached',
+        cf_connecting_ip: '1000:1000:1000::100',
+      },
+      cf: {
+        longitude: '11.11111',
+        httpProtocol: 'HTTP/1.1',
+        continent: 'EU',
+        clientAcceptEncoding: 'gzip, br',
+        city: 'MockCity',
+        timezone: 'Europe/Berlin',
+        region: 'MockRegion',
+        country: 'MO',
+        onlyIfCachedGateways: '["https://w3s.link"]',
+      },
+    },
+    cloudflare_worker: {
+      version: '1.13.0',
+      commit: 'da90000000000000403e6f9c2742aea033333333',
+      branch: 'main',
+      worker_id: 'XXXXXX1_-X',
+      worker_started: 1_731_095_284_725,
+    },
+    response: {
+      headers: {
+        access_control_allow_origin: '*',
+        access_control_expose_headers: 'Link',
+        server_timing: 'request;dur=23',
+      },
+      status_code: 412,
+      duration: 23,
+    },
+  }
+
+  log.time('testing')
+  log.log('testing message', 'info', '', metadata)
+  log.timeEnd('testing')
+
+  t.is(log.logEventsBatch.length, 1)
+  t.deepEqual(Object.keys(log.logEventsBatch[0].metadata), [
+    'request',
+    'response',
+  ])
+  t.deepEqual(Object.keys(log.logEventsBatch[0].metadata.request), [
+    'url',
+    'method',
+  ])
 })
 
 /**

--- a/packages/utils/test/loki.test.js
+++ b/packages/utils/test/loki.test.js
@@ -1,0 +1,58 @@
+import test from 'ava'
+import { Request } from '@web-std/fetch'
+import { Logging } from '../src/loki.js'
+
+function logging() {
+  return new Logging(
+    new Request('http://localhost'),
+    { waitUntil: async () => {}, passThroughOnException: () => {} },
+    {
+      url: 'test',
+      worker: 'test',
+      branch: 'test',
+      commit: 'test',
+      version: 'test',
+      env: 'test',
+    }
+  )
+}
+
+test('should add a log to the batch ', async (t) => {
+  const log = logging()
+
+  log.log('testing', 'info')
+
+  t.is(log.logEventsBatch[0].level, 'info')
+  t.is(log.logEventsBatch[0].message, 'testing')
+})
+
+test('should not log with time', async (t) => {
+  const log = logging()
+
+  log.time('testing', 'description')
+
+  t.is(log.logEventsBatch.length, 0)
+  t.is(log._times.get('testing').name, 'testing')
+  t.is(log._times.get('testing').description, 'description')
+  t.assert(Date.now() >= log._times.get('testing').start)
+})
+
+test('should not log with timeend', async (t) => {
+  const log = logging()
+
+  log.time('testing')
+  await sleep(2000)
+  log.timeEnd('testing')
+
+  t.is(log.logEventsBatch.length, 0)
+  t.assert(log._times.get('testing').end > log._times.get('testing').start)
+  t.is(
+    log._times.get('testing').duration,
+    log._times.get('testing').end - log._times.get('testing').start
+  )
+})
+
+/**
+ * @param {number} ms
+ */
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/packages/utils/test/loki.test.js
+++ b/packages/utils/test/loki.test.js
@@ -28,7 +28,7 @@ function loggingWithFilteredFields() {
       commit: 'test',
       version: 'test',
       env: 'test',
-      filterFields: (log) => {
+      logDataTransformer: (log) => {
         const { metadata } = log
         // Customize which fields to include
         const filteredMetadata = {
@@ -68,7 +68,7 @@ test('should not log with timeend', async (t) => {
   const log = logging()
 
   log.time('testing')
-  await sleep(2000)
+  await sleep(100) // Ensure start time differs from end time
   log.timeEnd('testing')
 
   t.is(log.logEventsBatch.length, 0)


### PR DESCRIPTION
### Description

This PR introduces a `logDataTransformer` callback option to the Loki Logging class, allowing users to filter or transform fields in a log.

### Motivation

This package is used in several workers, and the logs stored contain many unnecessary fields that can be removed to reduce log data size and lower costs. More details on this issue can be found at https://github.com/storacha/project-tracking/issues/175.

### Changes

- Add a `logDataTransformer` callback to the Loki Logging constructor for custom log transformation.
- Update `_add` method to apply `logDataTransformer ` when provided.
- Add unit tests for `loki.js`.
- Update type definitions for improved accuracy.